### PR TITLE
[README] add crosscut account set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The app lets you:
 - Create visualizations and maps in DHIS2 by combining the catchment areas with DHIS2 reporting data
 - Generate target population estimates for each catchment area to quickly calculate coverage estimates
 - See travel time to the health facilities within the catchment area to support outreach and session planning
+- Requirements: An account with Crosscut (a third party application) 
+
+Account set-up options:
+1. After installing the Microplanning app, set up an account with Crosscut via the DHIS2 interface
+2. Go to app.crosscut.io to set up an account with Crosscut
 
 ## User Guide
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The app lets you:
 
 Account set-up options:
 1. After installing the Microplanning app, set up an account with Crosscut via the DHIS2 interface
-2. Go to app.crosscut.io to set up an account with Crosscut
+2. Go to [app.crosscut.io](https://app.crosscut.io/) to set up an account with Crosscut
 
 ## User Guide
 


### PR DESCRIPTION
This PR adds information on setting up an account with Crosscut on DHIS2 interface or app.crosscut.io as a requirement to use the microplanning app. This is the description that will be added to the app on DHIS2.