### PR TITLE
update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dhis2-crosscut-app",
   "author": "crosscut.io",
-  "version": "4.0.0",
+  "version": "1.0.0",
   "description": "",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
This PR sets the version back to 1.0.0. Will set up the continuous delivery piece: https://developers.dhis2.org/docs/guides/publish-apphub/