### PR TITLE
Request all boundaries instead of just v3 boundaries

### DIFF
--- a/src/api/crosscutRequests.js
+++ b/src/api/crosscutRequests.js
@@ -272,8 +272,7 @@ export const deleteCatchmentJob = async (id) => {
 };
 
 export const fetchSupportedBoundaries = async () => {
-  const boundaryVerion = 'v3';
-  const url = `${baseURL}/boundaries/${boundaryVerion}`;
+  const url = `${baseURL}/boundaries`;
   try {
     const resp = await ky(url, {
       mode: 'cors',


### PR DESCRIPTION
Before (only v3 boundaries are returned, which doesn't include Eswatini):
<img width="2557" alt="Screenshot 2023-11-29 at 11 44 08 AM" src="https://github.com/crosscutio/dhis2-crosscut-app/assets/13878539/a2d7c911-b3ec-4e58-a8c6-58d57b042ece">


After (all v3 and v4 boundaries are returned):
<img width="2560" alt="Screenshot 2023-11-29 at 11 41 57 AM" src="https://github.com/crosscutio/dhis2-crosscut-app/assets/13878539/b1b3d458-c635-4d07-b8d7-17b124de2097">
